### PR TITLE
Add config option to not post tags from gelbooru-style sites

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,7 @@ Note that you can only have one of each %metatag, and there isn't a %tag for you
 --------------------------|--------------
 `%no_deleted`             | Don't tweet deleted posts
 `%errors`                 | Send error logs to owner via DMs
+`%hide_gelbooru_tags`     | Prevents display of tags for images posted from gelbooru-style sites.
 
 [rufs]: https://github.com/jmettraux/rufus-scheduler#rufus-scheduler
 [gelbs]: #gelbooru-api-support

--- a/lib/gelbooru.rb
+++ b/lib/gelbooru.rb
@@ -93,7 +93,7 @@ module Gelbooru
       'file_ext' => post['image'].match(/\.(?<ext>\w+)\z/)['ext'],
       'rating' => post.empty? ? '' : post['rating'][0],
       'tag_string_character' => '',
-      'tag_string_copyright' => post['tags'],
+      'tag_string_copyright' => config.hide_gelbooru_tags ? ' ' : post['tags'],
       'tag_string_artist' => '',
       '__api' => api,
       '__api_type' => :gelbooru,


### PR DESCRIPTION
Sometimes it might be nice to just post the source url instead of all the tags.
