### PR TITLE
Fixed gelbooru bots not setting @last_timed_tweet_time at startup

### DIFF
--- a/lib/danbooru.rb
+++ b/lib/danbooru.rb
@@ -38,7 +38,10 @@ module Danbooru
           # If it hasn't been set, set last tweet time to time of this tweet
           @last_timed_tweet_time ||= tweet.created_at
         else
-          gelbooru_populate_history uri
+          # If gelbooru_poplate_history succeeds, set last tweet time if it hasn't been set
+          unless gelbooru_populate_history(uri) == nil
+            @last_timed_tweet_time ||= tweet.created_at
+          end
         end
       end
     end


### PR DESCRIPTION
Gelbooru bots were crashing because they were no longer setting a last tweet time when they started up :<
This should fix that!
